### PR TITLE
[Ruby] Add `BuiltinPackageDownloader` scraper

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,16 +8,16 @@ val joernVersion = "2.0.339"
 val overflowdbVersion = "1.191"
 
 libraryDependencies ++= Seq(
-  "com.github.pathikrit" %% "better-files" % "3.9.2",
-  "com.github.scopt" %% "scopt" % "4.1.0",
-  "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.20.0" % Optional,
+  "com.github.pathikrit" %% "better-files" % Versions.betterFiles,
+  "com.github.scopt" %% "scopt" % Versions.scopt,
+  "org.apache.logging.log4j" % "log4j-slf4j2-impl" % Versions.log4j % Optional,
   "io.joern" %% "x2cpg" % Versions.joern,
   "io.joern" %% "rubysrc2cpg" % Versions.joern,
   "io.joern" %% "joern-cli" % Versions.joern,
   "io.joern" %% "semanticcpg" % Versions.joern,
   "io.joern" %% "semanticcpg" % Versions.joern % Test classifier "tests",
-  "org.scalatest" %% "scalatest" % "3.2.16" % Test,
-  "net.ruippeixotog" %% "scala-scraper" % "3.1.1",
+  "net.ruippeixotog" %% "scala-scraper" % Versions.scalaScraper,
+  "org.scalatest" %% "scalatest" % Versions.scalatest % Test
 )
 
 // mostly so that `sbt assembly` works, but also to ensure that we don't end up

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 name := "joern-type-stubs"
 ThisBuild / organization := "io.joern"
-ThisBuild / scalaVersion := "3.3.1"
+ThisBuild / scalaVersion := "3.4.1"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val cpgVersion = "1.6.10"
-val joernVersion = "2.0.310"
-val overflowdbVersion = "1.190"
+val cpgVersion = "1.6.11"
+val joernVersion = "2.0.339"
+val overflowdbVersion = "1.191"
 
 libraryDependencies ++= Seq(
   "com.github.pathikrit" %% "better-files" % "3.9.2",
@@ -16,7 +16,8 @@ libraryDependencies ++= Seq(
   "io.joern" %% "joern-cli" % Versions.joern,
   "io.joern" %% "semanticcpg" % Versions.joern,
   "io.joern" %% "semanticcpg" % Versions.joern % Test classifier "tests",
-  "org.scalatest" %% "scalatest" % "3.2.16" % Test
+  "org.scalatest" %% "scalatest" % "3.2.16" % Test,
+  "net.ruippeixotog" %% "scala-scraper" % "3.1.1",
 )
 
 // mostly so that `sbt assembly` works, but also to ensure that we don't end up

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,6 +3,12 @@ object Versions {
   val joern = parseVersion("joernVersion")
   val overflowdb = parseVersion("overflowdbVersion")
 
+  val scalatest = "3.2.16"
+  val betterFiles = "3.9.2"
+  val scopt = "4.1.0"
+  val log4j = "2.20.0"
+  val scalaScraper = "3.1.1"
+
   private def parseVersion(key: String): String = { 
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r
     val versions: List[String] = scala.io.Source

--- a/src/main/scala/io/joern/typestubs/Main.scala
+++ b/src/main/scala/io/joern/typestubs/Main.scala
@@ -1,7 +1,11 @@
 package io.joern.typestubs
 
+import io.joern.typestubs.ruby.BuiltinPackageDownloader
+
 /** Example program that makes use of Joern as a library */
 object Main {
-  def main(args: Array[String]): Unit = {}
-
+  def main(args: Array[String]): Unit = {
+    val rubyScraper = BuiltinPackageDownloader()
+    rubyScraper.run()
+  }
 }

--- a/src/main/scala/io/joern/typestubs/Main.scala
+++ b/src/main/scala/io/joern/typestubs/Main.scala
@@ -2,7 +2,6 @@ package io.joern.typestubs
 
 /** Example program that makes use of Joern as a library */
 object Main {
-
   def main(args: Array[String]): Unit = {}
 
 }

--- a/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
+++ b/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
@@ -17,16 +17,17 @@ import upickle.default.ReadWriter
 
 // TODO: Remove when the ReadWriter changes are released on Joern
 case class RubyMethod(
-                       name: String,
-                       parameterTypes: List[(String, String)],
-                       returnType: String,
-                       baseTypeFullName: Option[String]
-                     ) extends MethodLike derives ReadWriter
+  name: String,
+  parameterTypes: List[(String, String)],
+  returnType: String,
+  baseTypeFullName: Option[String]
+) extends MethodLike
+    derives ReadWriter
 
 case class RubyField(name: String, typeName: String) extends FieldLike derives ReadWriter
 
 case class RubyType(name: String, methods: List[RubyMethod], fields: List[RubyField])
-  extends TypeLike[RubyMethod, RubyField] derives ReadWriter {
+    extends TypeLike[RubyMethod, RubyField] derives ReadWriter {
 
   @targetName("add")
   override def +(o: TypeLike[RubyMethod, RubyField]): TypeLike[RubyMethod, RubyField] = {

--- a/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
+++ b/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
@@ -144,9 +144,6 @@ class BuiltinPackageDownloader(rubyVersion: String = "3.3.0") {
       val msg: upack.Msg = upickle.default.writeMsg(gemsMap)
       typesFile.writeByteArray(upack.writeToByteArray(msg))
     }
-
-    dir.zipTo(destination = File(s"${baseDir}.zip"))
-    dir.delete()
   }
 
   // TODO: Remove before merging to master at a later stage

--- a/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
+++ b/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
@@ -1,0 +1,231 @@
+package io.joern.typestubs.ruby
+
+import better.files.File
+import io.joern.rubysrc2cpg.datastructures.{RubyMethod, RubyType}
+import io.joern.x2cpg.Defines
+import io.joern.x2cpg.utils.ConcurrentTaskUtil
+import net.ruippeixotog.scalascraper.browser.JsoupBrowser
+import net.ruippeixotog.scalascraper.dsl.DSL.*
+import net.ruippeixotog.scalascraper.dsl.DSL.Extract.*
+import net.ruippeixotog.scalascraper.model.Element
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.util.{Failure, Success}
+
+/** Class to scrape and generate Ruby Namespace Map for builtin Ruby packages from https://ruby-doc.org
+  * @param rubyVersion
+  *   \- Ruby version to fetch dependencies for
+  */
+class BuiltinPackageDownloader(rubyVersion: String = "3.3.0") {
+  private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  private val CLASS    = "class"
+  private val INSTANCE = "instance"
+
+  private val browser = JsoupBrowser()
+  private val baseUrl = s"https://ruby-doc.org/$rubyVersion"
+
+  private val baseDir = "src/main/resources/builtin_types"
+
+  // Below unicode value caluclated with: println("\\u" + Integer.toHexString('→' | 0x10000).substring(1))
+  // taken from: https://stackoverflow.com/questions/2220366/get-unicode-value-of-a-character
+  private val arrowUnicodeValue = "\\u2192"
+
+  def run(): Unit = {
+    val builtinDir = File(baseDir)
+    builtinDir.createDirectoryIfNotExists()
+
+    val paths = generatePaths()
+
+    val typesMap = collection.mutable.Map[String, List[RubyType]]()
+
+    val types = ConcurrentTaskUtil
+      .runUsingThreadPool(generateRubyTypes(paths))
+      .flatMap {
+        case Success(rubyTypes) =>
+          typesMap.addOne(rubyTypes._1, rubyTypes._2)
+        case Failure(ex) =>
+          logger.warn(s"Failed to scrape/write Ruby builtin types: $ex")
+          None
+      }
+
+    writeToFileJson(typesMap)
+    writeToFile(typesMap)
+  }
+
+  /** Generates a `RubyType` for each class/module in each gem
+    * @param pathsMap
+    * @return
+    */
+  private def generateRubyTypes(
+    pathsMap: collection.mutable.Map[String, List[String]]
+  ): Iterator[() => (String, List[RubyType])] = {
+    pathsMap
+      .map((gemName, paths) =>
+        () => {
+          val rubyTypes = paths.map { path =>
+            val doc = browser.get(path)
+
+            val namespace =
+              doc >?> element("h1.class, h1.module") match {
+                case Some(classOrModuleElement) =>
+                  // Text on website is: Class/Module <some>::<module/class>::<name>
+                  val classOrModuleName = classOrModuleElement.text.split("\\s")(1).replaceAll("::", "\\.").strip
+                  s"$gemName.$classOrModuleName"
+                case None => gemName
+              }
+
+            val rubyMethods = buildRubyMethods(doc, namespace)
+
+            RubyType(namespace, rubyMethods, List.empty)
+          }
+          (gemName, rubyTypes)
+        }
+      )
+      .iterator
+  }
+
+  private def writeToFile(rubyTypesMap: collection.mutable.Map[String, List[RubyType]]): Unit = {
+    val dir = File(s"${baseDir}/")
+    dir.createDirectoryIfNotExists()
+
+    rubyTypesMap.foreach { (gem, rubyTypes) =>
+      // gem is file name
+      val gemsMap = collection.mutable.Map[String, List[RubyType]]()
+
+      rubyTypes.foreach { rubyType =>
+        val rubyTypeNameSegments = rubyType.name.split("\\.")
+
+        val namespaceKey = rubyTypeNameSegments.size match {
+          case x if x == 1 =>
+            ""
+          case x if x > 1 =>
+            rubyTypeNameSegments.take(x - 1).mkString(".")
+        }
+
+        if gemsMap.contains(namespaceKey) then gemsMap.update(namespaceKey, gemsMap(namespaceKey) :+ rubyType)
+        else gemsMap.put(namespaceKey, List(rubyType))
+      }
+
+      val typesFile = File(s"${dir.pathAsString}/$gem.mpk")
+      typesFile.createIfNotExists()
+
+//      val msg: upack.Msg = upickle.default.writeMsg(gemsMap)
+//      typesFile.writeByteArray(upack.writeToByteArray(msg))
+    }
+
+    dir.zipTo(destination = File(s"${baseDir}.zip"))
+    dir.delete()
+  }
+
+  // TODO: Remove before merging to master at a later stage
+  private def writeToFileJson(rubyTypesMap: collection.mutable.Map[String, List[RubyType]]): Unit = {
+    val dir = File(s"${baseDir}_json/")
+    dir.createDirectoryIfNotExists()
+
+    rubyTypesMap.foreach { (gem, rubyTypes) =>
+      // gem is file name
+      val gemsMap = collection.mutable.Map[String, List[RubyType]]()
+
+      rubyTypes.foreach { rubyType =>
+        val rubyTypeNameSegments = rubyType.name.split("\\.")
+
+        val namespaceKey = rubyTypeNameSegments.size match {
+          case x if x == 1 =>
+            ""
+          case x if x > 1 =>
+            rubyTypeNameSegments.take(x - 1).mkString(".")
+        }
+
+        if gemsMap.contains(namespaceKey) then gemsMap.update(namespaceKey, gemsMap(namespaceKey) ++ List(rubyType))
+        else gemsMap.put(namespaceKey, List(rubyType))
+      }
+
+      val typesFile = File(s"${dir.pathAsString}/$gem.json")
+      typesFile.createIfNotExists()
+
+//      typesFile.write(upickle.default.write(gemsMap, indent = 2))
+    }
+
+    dir.zipTo(destination = File(s"${baseDir}_json.zip"))
+    dir.delete()
+  }
+
+  /** Scrapes the given RubyDoc page and generates a `RubyMethod` for each public class and instance method found
+    * @param doc
+    *   \- page to scrape
+    * @param namespace
+    * @return
+    *   \- List of RubyMethod's for the given class/module
+    */
+  private def buildRubyMethods(doc: browser.DocumentType, namespace: String): List[RubyMethod] = {
+    def generateMethodHeadingsSelector(methodType: String): String = {
+      s"#public-$methodType-5Buntitled-5D-method-details > .method-detail > .method-heading"
+    }
+
+    val methodHeadings =
+      doc >> elementList(s"${generateMethodHeadingsSelector(CLASS)}, ${generateMethodHeadingsSelector(INSTANCE)}")
+
+    val methodElements = methodHeadings >> element(".method-callseq, .method-name")
+
+    val funcNameRegex = "^([^{(]+)".r
+
+    methodElements
+      .map { x =>
+        val method = x.text.split(arrowUnicodeValue)(0)
+
+        funcNameRegex.findFirstMatchIn(method) match {
+          case Some(methodName) =>
+            // Some methods are `methodName == something`, which is why the split on space here is required
+            s"${methodName.toString.replaceAll("[!?=]", "").split("\\s+")(0).strip}"
+          case None => ""
+        }
+      }
+      .filterNot(_ == "")
+      .distinct
+      .map(x => RubyMethod(s"$namespace.$x", List.empty, Defines.Any, Option(namespace)))
+  }
+
+  /** Generates links for all classes on the RubyDocs page
+    * @return
+    *   Map[gemName -> list of paths]
+    */
+  private def generatePaths(): collection.mutable.Map[String, List[String]] = {
+    val doc = browser.get(baseUrl)
+
+    val liElements = doc >> elementList("#classindex-section > .link-list > li")
+
+    val linksMap = collection.mutable.Map[String, List[String]]()
+
+    val baseItems = liElements.takeWhile { x =>
+      !x.hasAttr("class") || !(x.attr("class") == "gemheader")
+    }
+
+    val (_, restOfItems) = liElements.splitAt(baseItems.size + 1)
+
+    val links = (restOfItems >> elementList("a")).filter(_.nonEmpty).map(_.head).groupBy(_.attr("href").split("/")(2))
+
+    val baseLinks = baseItems.map { x =>
+      val anchor = x >?> element("a")
+      s"$baseUrl/${anchor.get.attr("href").replaceAll("\\./", "")}"
+    }
+
+    linksMap.addOne("__builtin", baseLinks)
+
+    links.foreach { (extensionName, anchorElements) =>
+      val anchorHrefs = anchorElements
+        .map { anchorElement =>
+          s"$baseUrl/${anchorElement.attr("href").replaceAll("\\./", "")}"
+        }
+        .filter(!_.contains("table_of_contents"))
+
+      linksMap.get(extensionName) match {
+        case Some(prevHrefs) if prevHrefs.length < anchorHrefs.length => linksMap.update(extensionName, anchorHrefs)
+        case Some(prevHrefs)                                          => // do nothing
+        case None                                                     => linksMap.addOne(extensionName, anchorHrefs)
+      }
+    }
+
+    linksMap
+  }
+}


### PR DESCRIPTION
This PR:
 * Scrape [rubydoc](https://ruby-doc.org/3.3.0/) to generate a NamespaceTypeMap for builtin ruby packages
 * Generate .zip folder with MessagePack files for each of the gems to be re-used
 * Write to JSON for sanity checking (to be removed)