### PR TITLE
[ruby] Fix constructor names for builtin types

### DIFF
--- a/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
+++ b/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
@@ -197,8 +197,7 @@ class BuiltinPackageDownloader(outputDir: String, format: OutputFormat.Value = O
             // Some methods are `methodName == something`, which is why the split on space here is required
             val parsedMethodName = s"${methodName.toString.replaceAll("[!?=]", "").split("\\s+")(0).strip}"
 
-            if parsedMethodName == "new" then
-              Defines.ConstructorMethodName
+            if parsedMethodName == "new" then Defines.ConstructorMethodName
             else parsedMethodName
           case None => ""
         }

--- a/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
+++ b/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
@@ -13,7 +13,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.annotation.targetName
 import scala.util.{Failure, Success}
-import upickle.default.ReadWriter
+import upickle.default.*
 
 // TODO: Remove when the ReadWriter changes are released on Joern
 case class RubyMethod(
@@ -22,7 +22,13 @@ case class RubyMethod(
   returnType: String,
   baseTypeFullName: Option[String]
 ) extends MethodLike
-    derives ReadWriter
+
+object RubyMethod {
+  implicit val rubyMethodRwJson: ReadWriter[RubyMethod] = readwriter[ujson.Value].bimap[RubyMethod](
+    x => ujson.Obj("name" -> x.name),
+    json => RubyMethod(json("name").str, List.empty, "", Option.empty)
+  )
+}
 
 case class RubyField(name: String, typeName: String) extends FieldLike derives ReadWriter
 
@@ -94,6 +100,7 @@ class BuiltinPackageDownloader(outputDir: String, format: OutputFormat.Value = O
   ): Iterator[() => (String, List[RubyType])] = {
     logger.info("[Ruby]: Generating Ruby Types for builtin functions")
     pathsMap
+      .slice(0, 5)
       .map((gemName, paths) =>
         () => {
           logger.debug(s"[Ruby]: Generating types for gem: $gemName")
@@ -188,7 +195,11 @@ class BuiltinPackageDownloader(outputDir: String, format: OutputFormat.Value = O
         funcNameRegex.findFirstMatchIn(method) match {
           case Some(methodName) =>
             // Some methods are `methodName == something`, which is why the split on space here is required
-            s"${methodName.toString.replaceAll("[!?=]", "").split("\\s+")(0).strip}"
+            val parsedMethodName = s"${methodName.toString.replaceAll("[!?=]", "").split("\\s+")(0).strip}"
+
+            if parsedMethodName == "new" then
+              Defines.ConstructorMethodName
+            else parsedMethodName
           case None => ""
         }
       }


### PR DESCRIPTION
This PR handles:
 * Change constructor names `.new` to x2cpg standard - `Defines.ConstructorMethodName`