### PR TITLE
[ruby] Fix constructor naming for builtin type gen

### DIFF
--- a/src/main/scala/io/joern/typestubs/Main.scala
+++ b/src/main/scala/io/joern/typestubs/Main.scala
@@ -11,7 +11,8 @@ object OutputFormat extends Enumeration {
 final case class Config(
   format: OutputFormat.Value = OutputFormat.zip,
   languageFrontend: String = Frontend.ALL,
-  outputDirectory: String = "./builtin_types"
+  outputDirectory: String = "./builtin_types",
+  useSubset: Boolean = false
 ) {
 
   def withFormat(value: OutputFormat.Value): Config = {
@@ -24,6 +25,10 @@ final case class Config(
 
   def withOutputDirectory(value: String): Config = {
     copy(outputDirectory = value)
+  }
+
+  def withUseSubset(value: Boolean): Config = {
+    copy(useSubset = value)
   }
 }
 
@@ -56,7 +61,10 @@ private object Frontend {
                 .mkString(",")}]".stripMargin),
       opt[String]("output")
         .action((x, c) => c.withOutputDirectory(x))
-        .text("Directory for type-stubs output")
+        .text("Directory for type-stubs output"),
+      opt[Unit]("useSubset")
+        .action((_, c) => c.withUseSubset(true))
+        .text("Only scrape the first 10 gems and generate types")
     )
   }
 }
@@ -81,7 +89,11 @@ object Main {
 
   def run(config: Config): Unit = {
     if config.languageFrontend == Frontend.ALL || config.languageFrontend == Languages.RUBYSRC then
-      val rubyScraper = BuiltinPackageDownloader(outputDir = config.outputDirectory, format = config.format)
+      val rubyScraper = BuiltinPackageDownloader(
+        outputDir = config.outputDirectory,
+        format = config.format,
+        useSubset = config.useSubset
+      )
       rubyScraper.run()
   }
 }

--- a/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
+++ b/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
@@ -19,7 +19,11 @@ import upickle.default.*
   * @param rubyVersion
   *   \- Ruby version to fetch dependencies for
   */
-class BuiltinPackageDownloader(outputDir: String, format: OutputFormat.Value = OutputFormat.zip) {
+class BuiltinPackageDownloader(
+  outputDir: String,
+  format: OutputFormat.Value = OutputFormat.zip,
+  useSubset: Boolean = false
+) {
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   private val CLASS    = "class"
@@ -65,11 +69,19 @@ class BuiltinPackageDownloader(outputDir: String, format: OutputFormat.Value = O
     * @param pathsMap
     * @return
     */
-  private def generateRubyTypes(
+  private def generateRubyTypesSet(
     pathsMap: collection.mutable.Map[String, List[String]]
   ): Iterator[() => (String, List[RubyType])] = {
     logger.info("[Ruby]: Generating Ruby Types for builtin functions")
-    pathsMap
+
+    if useSubset then generateRubyTypes(pathsMap.slice(0, 20))
+    else generateRubyTypes(pathsMap)
+  }
+
+  private def generateRubyTypes(
+    paths: collection.mutable.Map[String, List[String]]
+  ): Iterator[() => (String, List[RubyType])] = {
+    paths
       .map((gemName, paths) =>
         () => {
           logger.debug(s"[Ruby]: Generating types for gem: $gemName")

--- a/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
+++ b/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
@@ -74,7 +74,7 @@ class BuiltinPackageDownloader(
   ): Iterator[() => (String, List[RubyType])] = {
     logger.info("[Ruby]: Generating Ruby Types for builtin functions")
 
-    if useSubset then generateRubyTypes(pathsMap.slice(0, 20))
+    if useSubset then generateRubyTypes(pathsMap.slice(0, 10))
     else generateRubyTypes(pathsMap)
   }
 

--- a/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
+++ b/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
@@ -70,7 +70,6 @@ class BuiltinPackageDownloader(outputDir: String, format: OutputFormat.Value = O
   ): Iterator[() => (String, List[RubyType])] = {
     logger.info("[Ruby]: Generating Ruby Types for builtin functions")
     pathsMap
-      .slice(0, 20)
       .map((gemName, paths) =>
         () => {
           logger.debug(s"[Ruby]: Generating types for gem: $gemName")

--- a/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
+++ b/src/main/scala/io/joern/typestubs/ruby/BuiltinPackageDownloader.scala
@@ -70,6 +70,7 @@ class BuiltinPackageDownloader(outputDir: String, format: OutputFormat.Value = O
   ): Iterator[() => (String, List[RubyType])] = {
     logger.info("[Ruby]: Generating Ruby Types for builtin functions")
     pathsMap
+      .slice(0, 20)
       .map((gemName, paths) =>
         () => {
           logger.debug(s"[Ruby]: Generating types for gem: $gemName")
@@ -164,9 +165,10 @@ class BuiltinPackageDownloader(outputDir: String, format: OutputFormat.Value = O
         funcNameRegex.findFirstMatchIn(method) match {
           case Some(methodName) =>
             // Some methods are `methodName == something`, which is why the split on space here is required
-            val parsedMethodName = s"${methodName.toString.replaceAll("[!?=]", "").split("\\s+")(0).strip}"
+            val parsedMethodName =
+              s"${methodName.toString.replaceAll("[!?=]", "").replaceAll("::", ".").split("\\s+")(0).strip}"
 
-            if parsedMethodName == "new" then Defines.ConstructorMethodName
+            if parsedMethodName.endsWith("new") then Defines.ConstructorMethodName
             else parsedMethodName
           case None => ""
         }


### PR DESCRIPTION
This PR handles:
 * Entire parsed function names are now replaced with `<init>` if the `.new` is found. This handles one or two cases like `CSV::Table.new`
 * Added a `useSubset` option that only generates the types for 10 gems to make debugging easier.